### PR TITLE
change expand archive to use powershell method

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs/Configures Elastic Winlogbeat'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/anuriq/chef-winlogbeat' if respond_to?(:source_url)
 issues_url 'https://github.com/anuriq/chef-winlogbeat/issues' if respond_to?(:issues_url)
-version '1.0.2'
+version '1.0.3'
 
 supports 'windows'
 

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -49,11 +49,7 @@ node.default['winlogbeat']['service_dir'] = if node['winlogbeat']['version'].to_
 
 powershell_script 'Unzip Winlogbeat' do
   code <<-EOH
-  $shell = new-object -com shell.application
-  $zip = $shell.NameSpace('#{package_file}')
-  foreach($item in $zip.items()) {
-    $shell.Namespace('#{destination}').copyhere($item)
-  }
+    Expand-Archive '#{package_file}' '#{destination}'
   EOH
   not_if { ::File.exist?("#{node['winlogbeat']['service_dir']}\\winlogbeat.exe") }
 end


### PR DESCRIPTION
Instead of using powershell script that utilizes shell, use "Expand-Archive" powershell functionality to unzip zip files.

The fix is for nano / headless windows servers, where shell is not available.